### PR TITLE
build(Dependencies): Move to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-api-client",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Node.js / JavaScript client for Twitter API",
   "main": "dist/index.js",
   "scripts": {
@@ -29,14 +29,14 @@
   "homepage": "https://github.com/FeedHive/twitter-api-client#readme",
   "dependencies": {
     "@sinonjs/fake-timers": "^6.0.1",
-    "jest": "^26.1.0",
     "oauth": "^0.9.15",
-    "object-sizeof": "^1.6.1",
-    "ts-jest": "^26.1.3",
-    "typescript": "^3.8.3"
+    "object-sizeof": "^1.6.1"
   },
   "devDependencies": {
+    "jest": "^26.1.0",
     "@types/jest": "^26.0.5",
+    "ts-jest": "^26.1.3",
+    "typescript": "^3.8.3",
     "@types/node": "^13.11.1",
     "@types/oauth": "^0.9.1",
     "@types/sinonjs__fake-timers": "^6.0.1",


### PR DESCRIPTION
Move Typescript and test libraries to devDependencies so that they are not included as part of the build.