### PR TITLE
update GET /lists/members parameters

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -154,12 +154,24 @@ use GET lists / ownerships and/or GET lists / subscriptions instead.
 #### Link
 https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-list  
   
-### `TwitterClient.accountsAndUsers.listsMembers()`
+### `TwitterClient.accountsAndUsers.listsMembers(parameters)`
 #### Description
 members/*
 Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
 
 
+#### Parameters
+
+| Name | Required | type |
+| ---- | -------- | ---- |
+| list_id | true | number |
+| slug | true | string |
+| owner_screen_name | false | string |
+| owner_id | false | number |
+| count | false | number |
+| cursor | false | number |
+| include_entities | false | boolean |
+| skip_status | false | boolean |
   
 #### Link
 https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members  

--- a/src/specs/accounts-and-users.yml
+++ b/src/specs/accounts-and-users.yml
@@ -44,6 +44,49 @@ subgroups:
         description: |
           members/*
           Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
+        parameters:
+          - name: list_id
+            description: The numerical id of the list.
+            required: true
+            type: number
+          - name: slug
+            description: You can identify a list by its slug instead of its numerical
+              id. If you decide to do so, note that you'll also have to specify the list
+              owner using the owner_id or owner_screen_name parameters.
+            required: true
+            type: string
+          - name: owner_screen_name
+            description: The screen name of the user who owns the list being requested
+              by a slug.
+            required: false
+            type: string
+          - name: owner_id
+            description: The user ID of the user who owns the list being requested by
+              a slug.
+            required: false
+            type: number
+          - name: count
+            description: Specifies the number of results to return per page (see cursor below). 
+              The default is 20, with a maximum of 5,000.
+            required: false
+            type: number
+          - name: cursor
+            description: |
+              Causes the collection of list members to be broken into "pages" of consistent sizes (specified by the count parameter). 
+              If no cursor is provided, a value of -1 will be assumed, which is the first "page."
+              The response from the API will include a previous_cursor and next_cursor to allow paging back and forth. 
+              See Using cursors to navigate collections for more information.
+            required: false
+            type: number
+          - name: include_entities
+            description: |
+              The entities node will not be included when set to false.
+            required: false
+            type: boolean
+          - name: skip_status
+            description: When set to either true, t or 1 statuses will not be included in the returned user objects.
+            required: false
+            type: boolean
         exampleResponse: |
           {
             "users": [ {user-object} ],


### PR DESCRIPTION
The list parameters was not set for this request.

fix FeedHive/twitter-api-client/issues/42

**What does this pull request introduce? Please describe**  

This PR include the missing parameters of the `GET /lists/members` request, mentioned in #42 

**How did you verify that your changes work as expected? Please describe**  
Please describe your methods of testing your changes.

**Example**  
Please describe how we can try out your changes  

After generating the client

1. Create a new file in the project
2. Instantiate a new Twitter client (from the generated one)
3. Call the method `accountsAndUsers.listsMembers`

```typescript
import { TwitterClient } from "../generated/";

const API_KEY = "...";
const API_KEY_SECRET = "...";
const ACCESS_TOKEN = "...";
const ACCESS_TOKEN_SECRET = "...";

const client = new TwitterClient({
  apiKey: API_KEY,
  apiSecret: API_KEY_SECRET,
  accessToken: ACCESS_TOKEN,
  accessTokenSecret: ACCESS_TOKEN_SECRET,
});


const list_id = "..." // example : "1336067812780019713"

client.accountsAndUsers
  .listsMembers({
    list_id,
    slug: list_id,
  })
  .then(console.log)
  .catch(console.error);

```

**Screenshots**  

<details>
<summary>Script output</summary>
<br/>

```
❯ ts-node src/test.ts
{
  users: [
    {
      id: 862259629820174300,
      id_str: '862259629820174336',
      name: 'Shine',
      screen_name: 'shine_tools',
      location: 'Paris, France',
      description: 'La néobanque qui simplifie le quotidien des indépendants et petites entreprises',
      url: 'https://t.co/vFDBIPaBhP',
      entities: [Object],
      protected: false,
      followers_count: 3925,
      friends_count: 881,
      listed_count: 62,
      created_at: 'Wed May 10 10:54:50 +0000 2017',
      favourites_count: 933,
      utc_offset: null,
      time_zone: null,
      geo_enabled: false,
      verified: false,
      statuses_count: 3623,
      lang: null,
      status: [Object],
      contributors_enabled: false,
      is_translator: false,
      is_translation_enabled: false,
      profile_background_color: '000000',
      profile_background_image_url: 'http://abs.twimg.com/images/themes/theme1/bg.png',
      profile_background_image_url_https: 'https://abs.twimg.com/images/themes/theme1/bg.png',
      profile_background_tile: false,
      profile_image_url: 'http://pbs.twimg.com/profile_images/881790027075858432/smrsEqa__normal.jpg',
      profile_image_url_https: 'https://pbs.twimg.com/profile_images/881790027075858432/smrsEqa__normal.jpg',
      profile_banner_url: 'https://pbs.twimg.com/profile_banners/862259629820174336/1562329424',
      profile_link_color: '58C2FF',
      profile_sidebar_border_color: '000000',
      profile_sidebar_fill_color: '000000',
      profile_text_color: '000000',
      profile_use_background_image: false,
      has_extended_profile: false,
      default_profile: false,
      default_profile_image: false,
      following: false,
      follow_request_sent: false,
      notifications: false,
      translator_type: 'none'
    },
    {
      id: 35189444,
      id_str: '35189444',
      name: 'Arkéa',
      screen_name: 'cmarkea',
      location: 'France et Europe',
      description: "Fil d'information corporate d'Arkéa, groupe bancaire coopératif et collaboratif. Partenaire de l'écosystème numérique. #fintech",
      url: 'http://t.co/rIH0TfFgd6',
      entities: [Object],
      protected: false,
      followers_count: 11295,
      friends_count: 1792,
      listed_count: 664,
      created_at: 'Sat Apr 25 10:47:00 +0000 2009',
      favourites_count: 7804,
      utc_offset: null,
      time_zone: null,
      geo_enabled: true,
      verified: true,
      statuses_count: 19467,
      lang: null,
      status: [Object],
      contributors_enabled: false,
      is_translator: false,
      is_translation_enabled: false,
      profile_background_color: 'BE1435',
      profile_background_image_url: 'http://abs.twimg.com/images/themes/theme1/bg.png',
      profile_background_image_url_https: 'https://abs.twimg.com/images/themes/theme1/bg.png',
      profile_background_tile: false,
      profile_image_url: 'http://pbs.twimg.com/profile_images/1200048452849324032/7k09Op7c_normal.png',
      profile_image_url_https: 'https://pbs.twimg.com/profile_images/1200048452849324032/7k09Op7c_normal.png',
      profile_banner_url: 'https://pbs.twimg.com/profile_banners/35189444/1597240545',
      profile_link_color: '5B5C5C',
      profile_sidebar_border_color: 'FFFFFF',
      profile_sidebar_fill_color: 'DDEEF6',
      profile_text_color: '333333',
      profile_use_background_image: false,
      has_extended_profile: false,
      default_profile: false,
      default_profile_image: false,
      following: false,
      follow_request_sent: false,
      notifications: false,
      translator_type: 'none'
    }
  ],
  next_cursor: 0,
  next_cursor_str: '0',
  previous_cursor: 0,
  previous_cursor_str: '0',
  total_count: null
}
```

</details>

**Version**  
Which version is your changes included in?  
