### PR TITLE
Fix descriptions in basic specification

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -75,7 +75,12 @@ https://developer.twitter.com/en/docs/basics/authentication/api-reference/invali
   
 ### `TwitterClient.basics.oauth2InvalidateToken(parameters)`
 #### Description
-undefined
+Allows a registered application to revoke an issued oAuth 2.0 Bearer Token by presenting 
+its client credentials. Once a Bearer Token has been invalidated, new creation 
+attempts will yield a different Bearer Token and usage of the invalidated 
+token will no longer be allowed.Successful responses include a 
+JSON-structure describing the revoked Bearer Token.
+
 
 #### Parameters
 
@@ -88,11 +93,8 @@ https://developer.twitter.com/en/docs/basics/authentication/api-reference/invali
   
 ### `TwitterClient.basics.oauthRequestToken(parameters)`
 #### Description
-Allows a registered application to revoke an issued oAuth 2.0 Bearer Token by presenting 
-its client credentials. Once a Bearer Token has been invalidated, new creation 
-attempts will yield a different Bearer Token and usage of the invalidated 
-token will no longer be allowed.Successful responses include a 
-JSON-structure describing the revoked Bearer Token.
+Allows a Consumer application to obtain an OAuth Request Token to request user authorization. 
+This method fulfills Section 6.1 of the OAuth 1.0 authentication flow.
 
 
 #### Parameters

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-api-client",
-  "version": "1.1.0",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-api-client",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Node.js / JavaScript client for Twitter API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/specs/basic.yml
+++ b/src/specs/basic.yml
@@ -87,6 +87,12 @@ subgroups:
       - title: POST oauth2/invalidate_token
         url: https://developer.twitter.com/en/docs/basics/authentication/api-reference/invalidate_bearer_token
         resourceUrl: https://api.twitter.com/oauth2/invalidate_token
+        description: |
+          Allows a registered application to revoke an issued oAuth 2.0 Bearer Token by presenting 
+          its client credentials. Once a Bearer Token has been invalidated, new creation 
+          attempts will yield a different Bearer Token and usage of the invalidated 
+          token will no longer be allowed.Successful responses include a 
+          JSON-structure describing the revoked Bearer Token.
         parameters:
           - name: access_token
             description: The value of the bearer token to revoke
@@ -98,11 +104,8 @@ subgroups:
         url: https://developer.twitter.com/en/docs/basics/authentication/api-reference/request_token
         resourceUrl: https://api.twitter.com/oauth/request_token
         description: |
-          Allows a registered application to revoke an issued oAuth 2.0 Bearer Token by presenting 
-          its client credentials. Once a Bearer Token has been invalidated, new creation 
-          attempts will yield a different Bearer Token and usage of the invalidated 
-          token will no longer be allowed.Successful responses include a 
-          JSON-structure describing the revoked Bearer Token.
+          Allows a Consumer application to obtain an OAuth Request Token to request user authorization. 
+          This method fulfills Section 6.1 of the OAuth 1.0 authentication flow.
         parameters:
           - name: oauth_callback
             description: |


### PR DESCRIPTION
**What does this pull request introduce? Please describe**
``oauth2/invalidate_token`` had no description, while ``oauth/request_token`` had the description for ``oauth2/invalidate_token``

**How did you verify that your changes work as expected? Please describe**  
Both endpoints still work as expected.

**Version**  
Which version is your changes included in?
1.2.5

**PR Checklist**
Please verify that you:

- [x] Ran all unit tests, and they are passing
- [x] Wrote new unit tests if appropriate
- [x] Installed the client locally and tested it manually
- [x] Updated the version in `package.json`
