### PR TITLE
Deploy v. 1.3.0

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1701,7 +1701,7 @@ Returns a custom profile that was created with POST custom_profiles/new.json.
 #### Link
 https://developer.twitter.com/en/docs/direct-messages/custom-profiles/api-reference/get-profile  
   
-### `TwitterClient.directMessages.directMessagesEventsShow(parameters)`
+### `TwitterClient.directMessages.eventsShow(parameters)`
 #### Description
 Returns a single Direct Message event by the given id.
 
@@ -1714,7 +1714,7 @@ Returns a single Direct Message event by the given id.
 #### Link
 https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-event  
   
-### `TwitterClient.directMessages.directMessagesEventsNewMessageCreate(parameters)`
+### `TwitterClient.directMessages.eventsNew(parameters)`
 #### Description
 Publishes a new message_create event resulting in a Direct Message sent to a 
 specified user from the authenticating user. Returns an event if successful. 
@@ -1728,13 +1728,32 @@ Setting Content-Length may also be required if it is not automatically.
 
 | Name | Required | type |
 | ---- | -------- | ---- |
-| id | true | string |
-| data | true | string |
+| event | true | {
+  type: string;
+  message_create: {
+    target: {
+      recipient_id: string;
+    };
+    message_data: {
+      text: string;
+      quick_reply?: {
+        type: string[],
+      };
+      attachment?: {
+        type: string;
+        media: {
+          id: string;
+        }
+      };
+    }
+  }
+}
+ |
   
 #### Link
 https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event  
   
-### `TwitterClient.directMessages.directMessagesIndicateTyping(parameters)`
+### `TwitterClient.directMessages.indicateTyping(parameters)`
 #### Description
 Displays a visual typing indicator in the recipient’s 
 Direct Message conversation view with the sender. 
@@ -1751,7 +1770,7 @@ with a duration of ~3 seconds.
 #### Link
 https://developer.twitter.com/en/docs/direct-messages/typing-indicator-and-read-receipts/api-reference/new-typing-indicator  
   
-### `TwitterClient.directMessages.directMessagesWelcomeMessagesRulesShow(parameters)`
+### `TwitterClient.directMessages.welcomeMessagesRulesShow(parameters)`
 #### Description
 Returns a Welcome Message Rule by the given id.
 
@@ -1764,7 +1783,7 @@ Returns a Welcome Message Rule by the given id.
 #### Link
 https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/get-welcome-message-rule  
   
-### `TwitterClient.directMessages.directMessagesWelcomeMessagesShow(parameters)`
+### `TwitterClient.directMessages.welcomeMessagesShow(parameters)`
 #### Description
 Returns a Welcome Message by the given id.
 
@@ -1777,7 +1796,7 @@ Returns a Welcome Message by the given id.
 #### Link
 https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/get-welcome-message  
   
-### `TwitterClient.directMessages.directMessagesWelcomeMessagesNew(parameters)`
+### `TwitterClient.directMessages.welcomeMessagesNew(parameters)`
 #### Description
 Creates a new Welcome Message that will be stored and sent in the future 
 from the authenticating user in defined circumstances. 
@@ -1792,13 +1811,28 @@ See the Welcome Messages overview to learn how to work with Welcome Messages.
 
 | Name | Required | type |
 | ---- | -------- | ---- |
-| message_data | true | string |
+| welcome_message | true | {
+  message_data: {
+    text: string;
+    quick_reply?: {
+      type: string[],
+    };
+    attachment?: {
+      type: string;
+      media: {
+        id: string;
+      }
+    };
+  };
+  name?: string;
+}
+ |
 | name | false | string |
   
 #### Link
 https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/new-welcome-message  
   
-### `TwitterClient.directMessages.directMessagesWelcomeMessagesRulesNew(parameters)`
+### `TwitterClient.directMessages.welcomeMessagesRulesNew(parameters)`
 #### Description
 Creates a new Welcome Message Rule that determines which Welcome Message will be 
 shown in a given conversation. Returns the created rule if successful.
@@ -1814,7 +1848,10 @@ overview to learn how to work with Welcome Messages.
 
 | Name | Required | type |
 | ---- | -------- | ---- |
-| welcome_message_id | true | string |
+| welcome_message_rule | true | {
+  welcome_message_id: string;
+}
+ |
   
 #### Link
 https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/new-welcome-message-rule  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-api-client",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "Node.js / JavaScript client for Twitter API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/specs/direct-messages.yml
+++ b/src/specs/direct-messages.yml
@@ -29,7 +29,7 @@ subgroups:
 
   - title: Sending and receiving events
     endpoints:
-      - title: DELETE direct_messages/events/destroy
+      - title: DELETE events/destroy
         url: https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message-event
         resourceUrl: https://api.twitter.com/1.1/direct_messages/events/destroy.json
         description: |
@@ -45,7 +45,7 @@ subgroups:
             description: The id of the Direct Message event that should be deleted.
             required: true
             type: string
-      - title: GET direct_messages/events/show
+      - title: GET events/show
         url: https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-event
         resourceUrl: https://api.twitter.com/1.1/direct_messages/events/show.json
         description: Returns a single Direct Message event by the given id.
@@ -64,7 +64,7 @@ subgroups:
             }
           }
 
-      - title: POST direct_messages/events/new (message_create)
+      - title: POST events/new
         url: https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event
         resourceUrl: https://api.twitter.com/1.1/direct_messages/events/new.json
         description: |
@@ -75,15 +75,30 @@ subgroups:
           JSON POST body and Content-Type header to be set to application/json. 
           Setting Content-Length may also be required if it is not automatically.
         parameters:
-          - name: id
-            description: The ID of the user who should receive the direct message.
+          - name: event
+            description: Event object of the message event to send
             required: true
-            type: string
-          - name: data
-            description: The Message Data Object defining the content to deliver to the
-              reciepient.
-            required: true
-            type: string
+            type: |
+              {
+                type: string;
+                message_create: {
+                  target: {
+                    recipient_id: string;
+                  };
+                  message_data: {
+                    text: string;
+                    quick_reply?: {
+                      type: string[],
+                    };
+                    attachment?: {
+                      type: string;
+                      media: {
+                        id: string;
+                      }
+                    };
+                  }
+                }
+              }
         contentType: 'application/json'
         exampleResponse: |
           {
@@ -102,7 +117,7 @@ subgroups:
 
   - title: Typing indicator and read receipts
     endpoints:
-      - title: POST direct_messages/indicate_typing
+      - title: POST indicate_typing
         url: https://developer.twitter.com/en/docs/direct-messages/typing-indicator-and-read-receipts/api-reference/new-typing-indicator
         resourceUrl: https://api.twitter.com/1.1/direct_messages/indicate_typing.json
         description: |
@@ -118,7 +133,7 @@ subgroups:
 
   - title: Welcome Messages
     endpoints:
-      - title: GET direct_messages/welcome_messages/rules/show
+      - title: GET welcome_messages/rules/show
         url: https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/get-welcome-message-rule
         resourceUrl: https://api.twitter.com/1.1/direct_messages/welcome_messages/rules/show.json
         description: Returns a Welcome Message Rule by the given id.
@@ -136,7 +151,7 @@ subgroups:
             }
           }
 
-      - title: GET direct_messages/welcome_messages/show
+      - title: GET welcome_messages/show
         url: https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/get-welcome-message
         resourceUrl: https://api.twitter.com/1.1/direct_messages/welcome_messages/show.json
         description: Returns a Welcome Message by the given id.
@@ -160,7 +175,7 @@ subgroups:
             }
           }
 
-      - title: POST direct_messages/welcome_messages/new
+      - title: POST welcome_messages/new
         url: https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/new-welcome-message
         resourceUrl: https://api.twitter.com/1.1/direct_messages/welcome_messages/new.json
         description: |
@@ -172,13 +187,29 @@ subgroups:
           Setting Content-Length may also be required if it is not automatically.
           See the Welcome Messages overview to learn how to work with Welcome Messages.
         parameters:
-          - name: message_data
+          - name: welcome_message
             description: |
               The Message Data Object defining the content of the message template.
               See POST direct_messages/events/new (message_create) for Message Data object
               details.
             required: true
-            type: string
+            type: |
+              {
+                message_data: {
+                  text: string;
+                  quick_reply?: {
+                    type: string[],
+                  };
+                  attachment?: {
+                    type: string;
+                    media: {
+                      id: string;
+                    }
+                  };
+                };
+                name?: string;
+              }
+
           - name: name
             description: |
               A human readable name for the Welcome Message. This is not displayed
@@ -203,7 +234,7 @@ subgroups:
             "name": "simple_welcome-message 01"
           }
 
-      - title: POST direct_messages/welcome_messages/rules/new
+      - title: POST welcome_messages/rules/new
         url: https://developer.twitter.com/en/docs/direct-messages/welcome-messages/api-reference/new-welcome-message-rule
         resourceUrl: https://api.twitter.com/1.1/direct_messages/welcome_messages/rules/new.json
         description: |
@@ -216,10 +247,13 @@ subgroups:
           Welcome Message will be displayed in the conversation.See the Welcome Messages 
           overview to learn how to work with Welcome Messages.
         parameters:
-          - name: welcome_message_id
-            description: The ID of the Welcome Message that will be sent when this Rule is triggered.
+          - name: welcome_message_rule
+            description: The rule to be triggered
             required: true
-            type: string
+            type: |
+              {
+                welcome_message_id: string;
+              }
         contentType: 'application/json'
         exampleResponse: |
           {


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
Updating the `direct-messages` endpoints to include full parameter typing.
Multiple fixes are added to ensure that the correct JSON body is sent.

The method names for the endpoints have been further simplified.
Example.

Before it was:
`twitterClient.directMessages.directMessagesEventsNewMessageCreate()`

Now it is:
`twitterClient.directMessages.eventsNew()`

See the [REFERENCE](https://github.com/FeedHive/twitter-api-client/blob/master/REFERENCES.md#directmessages) to see the new endpoint names.

**Version**  
1.3.0
