### PR TITLE
Fix: return type of the home_timeline / statusesHomeTimeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-api-client",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Node.js / JavaScript client for Twitter API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/specs/v1/tweets.yml
+++ b/src/specs/v1/tweets.yml
@@ -290,9 +290,8 @@ subgroups:
             description: This parameter enables developers to request a series of different extended fields introduced in the years since statuses/show and statuses/lookup were introduced. It has been replaced with the fields and expansions functionality.
             required: false
             type: string
-
         exampleResponse: |
-          {tweet-object}
+          [ {tweet-object} ]
       - title: GET statuses/mentions_timeline
         url: https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-mentions_timeline
         resourceUrl: https://api.twitter.com/1.1/statuses/mentions_timeline.json
@@ -629,7 +628,8 @@ subgroups:
             required: false
             type: number
           - name: max_id
-            description: Returns results with an ID less than (that is, older than) or
+            description:
+              Returns results with an ID less than (that is, older than) or
               equal to the specified ID.
             required: false
             type: number
@@ -641,7 +641,8 @@ subgroups:
             required: false
             type: boolean
           - name: include_entities
-            description: The tweet entities node will not be included when set to false
+            description:
+              The tweet entities node will not be included when set to false
               .
             required: false
             type: boolean
@@ -703,7 +704,8 @@ subgroups:
             required: false
             type: boolean
           - name: include_card_uri
-            description: When set to either true , t or 1 , the retrieved Tweet will include
+            description:
+              When set to either true , t or 1 , the retrieved Tweet will include
               a card_uri attribute when there is an ads card attached to the Tweet and
               when that card was attached using the card_uri value.
             required: false
@@ -776,7 +778,8 @@ subgroups:
             required: true
             type: number
           - name: trim_user
-            description: When set to either true, t or 1, each tweet returned in a timeline
+            description:
+              When set to either true, t or 1, each tweet returned in a timeline
               will include a user object including only the status authors numerical ID.
               Omit this parameter to receive the complete user object.
             required: false
@@ -901,7 +904,8 @@ subgroups:
             required: true
             type: number
           - name: trim_user
-            description: When set to either true , t or 1 , each Tweet returned in a timeline
+            description:
+              When set to either true , t or 1 , each Tweet returned in a timeline
               will include a user object including only the status authors numerical ID.
               Omit this parameter to receive the complete user object.
             required: false

--- a/src/specs/v1/tweets.yml
+++ b/src/specs/v1/tweets.yml
@@ -628,8 +628,7 @@ subgroups:
             required: false
             type: number
           - name: max_id
-            description:
-              Returns results with an ID less than (that is, older than) or
+            description: Returns results with an ID less than (that is, older than) or
               equal to the specified ID.
             required: false
             type: number
@@ -641,8 +640,7 @@ subgroups:
             required: false
             type: boolean
           - name: include_entities
-            description:
-              The tweet entities node will not be included when set to false
+            description: The tweet entities node will not be included when set to false
               .
             required: false
             type: boolean
@@ -704,8 +702,7 @@ subgroups:
             required: false
             type: boolean
           - name: include_card_uri
-            description:
-              When set to either true , t or 1 , the retrieved Tweet will include
+            description: When set to either true , t or 1 , the retrieved Tweet will include
               a card_uri attribute when there is an ads card attached to the Tweet and
               when that card was attached using the card_uri value.
             required: false
@@ -778,8 +775,7 @@ subgroups:
             required: true
             type: number
           - name: trim_user
-            description:
-              When set to either true, t or 1, each tweet returned in a timeline
+            description: When set to either true, t or 1, each tweet returned in a timeline
               will include a user object including only the status authors numerical ID.
               Omit this parameter to receive the complete user object.
             required: false
@@ -904,8 +900,7 @@ subgroups:
             required: true
             type: number
           - name: trim_user
-            description:
-              When set to either true , t or 1 , each Tweet returned in a timeline
+            description: When set to either true , t or 1 , each Tweet returned in a timeline
               will include a user object including only the status authors numerical ID.
               Omit this parameter to receive the complete user object.
             required: false


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
This change is a minor fix on the return type of the home_timeline. The issue is described in more details at https://github.com/FeedHive/twitter-api-client/issues/71 .

**How did you verify that your changes work as expected? Please describe**  
Please describe your methods of testing your changes.

**Example**  
1. ran `npm install`
2. ran `npm run generate` + `npm run build` to create the TS module
3. used npm link to test the package locally and check the return type was corrected

**Screenshots**  
N.A.

**Version**  
Which version is your changes included in?

**PR Checklist**
Please verify that you:

- [x] Ran all unit tests, and they are passing
- [x] Wrote new unit tests if appropriate
- [x] Installed the client locally and tested it manually
- [x] Updated the version in `package.json`

Fixes https://github.com/FeedHive/twitter-api-client/issues/71