### PR TITLE
make retweeted_status optional

### DIFF
--- a/src/generator/template-models/tweet-template.json
+++ b/src/generator/template-models/tweet-template.json
@@ -303,7 +303,7 @@
   "retweeted": false,
   "possibly_sensitive": false,
   "lang": "en",
-  "retweeted_status": {
+  "retweeted_status--?": {
     "created_at": "Fri Oct 15 00:35:07 +0000 2021",
     "id": 1448809628934934530,
     "id_str": "1448809628934934530",


### PR DESCRIPTION
After digging into json-to-ts it looks like there is support for optional properties using a curious syntax (`--?` added to the end of the property key). You can see it [here](https://github.com/MariusAlch/json-to-ts/blob/40add7e3a4873e6a725a9fc860265a9500d35ea3/src/get-interfaces.ts#L10).

I tested it with retweeted_status in tweet-template.json & it worked as expected, producing this result:

```ts
export default interface StatusesHomeTimeline {
  ...
  retweeted_status?: Retweetedstatus;
}
```

I can't say I love this method as it requires modifying the raw JSON being returned from Twitter & is more error prone, but it seems better than nothing.

(copied from [here](https://github.com/FeedHive/twitter-api-client/pull/84#issuecomment-944521114))
