### PR TITLE
feat: add support for nested quoted_status & make quoted_status optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-api-client",
-  "version": "1.4.0",
+  "version": "1.5.1",
   "description": "Node.js / JavaScript client for Twitter API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/generator/template-models/tweet-template.json
+++ b/src/generator/template-models/tweet-template.json
@@ -185,9 +185,9 @@
   "place": null,
   "contributors": null,
   "is_quote_status": true,
-  "quoted_status_id": 1292831801648525314,
-  "quoted_status_id_str": "1292831801648525314",
-  "quoted_status": {
+  "quoted_status_id--?": 1292831801648525314,
+  "quoted_status_id_str--?": "1292831801648525314",
+  "quoted_status--?": {
     "created_at": "Mon Aug 10 14:34:55 +0000 2020",
     "id": 1292831801648525314,
     "id_str": "1292831801648525314",
@@ -422,7 +422,135 @@
     "coordinates": null,
     "place": null,
     "contributors": null,
-    "is_quote_status": false,
+    "is_quote_status": true,
+    "quoted_status_id--?": 1078376385440145408,
+    "quoted_status_id_str--?": "1078376385440145408",
+    "quoted_status--?": {
+      "created_at": "Thu Dec 27 19:45:40 +0000 2018",
+      "id": 1078376385440145408,
+      "id_str": "1078376385440145408",
+      "text": "When my kids are older I'm going to encourage them to go to @LambdaSchool. Following @AustenAllred &amp; reading about… https://t.co/5zZNpqlxim",
+      "truncated": true,
+      "entities": {
+        "hashtags": [
+          {
+            "text": "NowPlaying",
+            "indices": [0, 11]
+          },
+          {
+            "text": "listen",
+            "indices": [67, 74]
+          }
+        ],
+        "symbols": [],
+        "user_mentions": [
+          {
+            "screen_name": "LambdaSchool",
+            "name": "Lambda School",
+            "id": 733318062754004992,
+            "id_str": "733318062754004992",
+            "indices": [60, 73]
+          },
+          {
+            "screen_name": "AustenAllred",
+            "name": "Austen Allred",
+            "id": 1093528151123095552,
+            "id_str": "1093528151123095552",
+            "indices": [85, 98]
+          }
+        ],
+        "urls": [
+          {
+            "url": "https://t.co/5zZNpqlxim",
+            "expanded_url": "https://twitter.com/i/web/status/1078376385440145408",
+            "display_url": "twitter.com/i/web/status/1…",
+            "indices": [120, 143]
+          }
+        ]
+      },
+      "source": "<a href=\"http://twitter.com\" rel=\"nofollow\">Twitter Web Client</a>",
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 1398479138,
+        "id_str": "1398479138",
+        "name": "Claire Lehmann",
+        "screen_name": "clairlemon",
+        "location": "Sydney, Australia",
+        "description": "Founder @Quillette. Contributor @Australian.",
+        "url": "https://t.co/fMrptONv8n",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "https://t.co/fMrptONv8n",
+                "expanded_url": "https://linktr.ee/clairelehmann",
+                "display_url": "linktr.ee/clairelehmann",
+                "indices": [0, 23]
+              }
+            ]
+          },
+          "description": {
+            "urls": [
+              {
+                "url": "https://t.co/fMrptONv8n",
+                "expanded_url": "https://linktr.ee/clairelehmann",
+                "display_url": "linktr.ee/clairelehmann",
+                "indices": [0, 23]
+              }
+            ]
+          }
+        },
+        "protected": false,
+        "followers_count": 227062,
+        "friends_count": 4522,
+        "listed_count": 2415,
+        "created_at": "Fri May 03 00:18:34 +0000 2013",
+        "favourites_count": 65670,
+        "utc_offset": null,
+        "time_zone": null,
+        "geo_enabled": true,
+        "verified": true,
+        "statuses_count": 23557,
+        "lang": null,
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "EDECE9",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme3/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme3/bg.gif",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1370860449034498051/RaVOfBmt_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1370860449034498051/RaVOfBmt_normal.jpg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1398479138/1631429771",
+        "profile_link_color": "088253",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "E3E2DE",
+        "profile_text_color": "634047",
+        "profile_use_background_image": true,
+        "has_extended_profile": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false,
+        "translator_type": "none",
+        "withheld_in_countries": []
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "is_quote_status": false,
+      "retweet_count": 25,
+      "favorite_count": 373,
+      "favorited": false,
+      "retweeted": false,
+      "lang": "en"
+    },
     "retweet_count": 1,
     "favorite_count": 1,
     "favorited": false,


### PR DESCRIPTION
This PR has two changes
- makes `quoted_status` & associated properties (`quoted_status_id`, `quoted_status_id_str`) optional.
- adds support for `quoted_status` nested within `retweeted_status` which is present in the response Twitter provides. I have never seen Twitter return any statuses nested more deeply than this. (made optional a la previous bullet)