### PR TITLE
Add two v2 endpoints: one to retrieve user's information and one to retrieve user's timeline tweets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ This folder will contain the new client source code in TypeScript.
 Run the command:
 
 ```console
-npm build
+npm run build
 ```
 
 This will produce yet another folder `dist` in the root.  
@@ -74,13 +74,17 @@ npm install path/to/your/cloned/twitter-api-client/repository
 Consume the client and test that the new functionality works as expected.
 
 ### Update the version
+
 Before creating the PR, make sure to update the version using the principles of semantic versioning.  
-This is done by simple going to the `package.json` file and update the version.  
+This is done by simple going to the `package.json` file and update the version.
 
 ## Adding changes to the client
 
-In the `src` folder your will find a file `spec/twitter-api-spec.yml`.  
+In the `src` folder you will find a file `spec/twitter-api-spec.yml`.  
 This is the full specification of the Twitter API that is used in by this client.
+If you add a new endpoint group (eg, 'metrics' or 'tweets') you must add a new reference in the `spec/twitter-api-spec.yml` file.
+
+After adding the new reference, and the endpoint details in the `v1` or `v2` directories, run `npm run generate` to update the client (changes reflected in `REFERENCES.md`)
 
 When you run the command `npm run generate`, this file will be used to auto-generate a new client.  
 Any changes you make in this file will be reflected by the Twitter API Client.
@@ -146,7 +150,8 @@ The client follows the format:
 ```
 
 ## PR Checklist
-- I ran all unit tests, and they are passing  
+
+- I ran all unit tests, and they are passing
 - I wrote new unit tests if appropriate
-- I install the client locally and tested it manually 
+- I install the client locally and tested it manually
 - I updated the version in `package.json`

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -2198,7 +2198,7 @@ Creates a Tweet on behalf of an authenticated user.
  |
 | media | false | {
   media_ids: string[];
-  tagged_user_ids: string[];
+  tagged_user_ids?: string[];
 }
  |
 | poll | false | {
@@ -2208,7 +2208,7 @@ Creates a Tweet on behalf of an authenticated user.
  |
 | quote_tweet_id | false | string |
 | reply | false | {
-  exclude_reply_user_ids: string;
+  exclude_reply_user_ids?: string;
   in_reply_to_tweet_id: string;
 }
  |
@@ -2216,4 +2216,47 @@ Creates a Tweet on behalf of an authenticated user.
   
 #### Link
 https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets  
+  
+## Timelines
+### `TwitterClient.timelines.tweetsByUserId(parameters)`
+#### Description
+Returns Tweets composed by a single user, specified by the requested user ID. By default, the most recent ten Tweets are returned per request. Using pagination, the most recent 3,200 Tweets can be retrieved. The Tweets returned by this endpoint count towards the Project-level Tweet cap.
+
+#### Parameters
+
+| Name | Required | type |
+| ---- | -------- | ---- |
+| id | true | string |
+| end_time | false | date |
+| exclude | false | enum |
+| expansions | false | string |
+| max_results | false | integer |
+| media.fields | false | enum |
+| pagination_token | false | string |
+| place.fields | false | enum |
+| poll.fields | false | enum |
+| since_id | false | date |
+| tweet.fields | false | date |
+| until_id | false | string |
+| user.fields | false | enum |
+  
+#### Link
+https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets  
+  
+## Users
+### `TwitterClient.users.2UsersMe(parameters)`
+#### Description
+Return user informatino about an authorized user. User rate limit for OAuth 2.0 and OAuth 1.0a: 75 requests per 15-minute window per each authenticated user.
+
+
+#### Parameters
+
+| Name | Required | type |
+| ---- | -------- | ---- |
+| expansions | false | enum |
+| tweet.fields | false | enum |
+| user.fields | false | enum |
+  
+#### Link
+https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me  
   

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -2218,7 +2218,7 @@ Creates a Tweet on behalf of an authenticated user.
 https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets  
   
 ## Timelines
-### `TwitterClient.timelines.tweetsByUserId(parameters)`
+### `TwitterClient.timelines.usersIdTweets(parameters)`
 #### Description
 Returns Tweets composed by a single user, specified by the requested user ID. By default, the most recent ten Tweets are returned per request. Using pagination, the most recent 3,200 Tweets can be retrieved. The Tweets returned by this endpoint count towards the Project-level Tweet cap.
 
@@ -2227,35 +2227,20 @@ Returns Tweets composed by a single user, specified by the requested user ID. By
 | Name | Required | type |
 | ---- | -------- | ---- |
 | id | true | string |
-| end_time | false | date |
-| exclude | false | enum |
 | expansions | false | string |
-| max_results | false | integer |
-| media.fields | false | enum |
+| max_results | false | number |
 | pagination_token | false | string |
-| place.fields | false | enum |
-| poll.fields | false | enum |
-| since_id | false | date |
-| tweet.fields | false | date |
 | until_id | false | string |
-| user.fields | false | enum |
   
 #### Link
 https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets  
   
 ## Users
-### `TwitterClient.users.2UsersMe(parameters)`
+### `TwitterClient.users.usersMe()`
 #### Description
-Return user informatino about an authorized user. User rate limit for OAuth 2.0 and OAuth 1.0a: 75 requests per 15-minute window per each authenticated user.
+Return user information about an authorized user. User rate limit for OAuth 2.0 and OAuth 1.0a: 75 requests per 15-minute window per each authenticated user.
 
 
-#### Parameters
-
-| Name | Required | type |
-| ---- | -------- | ---- |
-| expansions | false | enum |
-| tweet.fields | false | enum |
-| user.fields | false | enum |
   
 #### Link
 https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "twitter-api-client",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.5.0",
+      "name": "twitter-api-client",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "oauth": "^0.9.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-api-client",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Node.js / JavaScript client for Twitter API",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FeedHive/twitter-api-client.git"
+    "url": "git+https://github.com/FeedHive/twitter-api-client"
   },
   "keywords": [
     "node.js",
@@ -24,9 +24,9 @@
   "author": "FeedHive",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/FeedHive/twitter-api-client/issues"
+    "url": "https://github.com/FeedHive/twitter-api-client"
   },
-  "homepage": "https://github.com/FeedHive/twitter-api-client#readme",
+  "homepage": "https://github.com/FeedHive/twitter-api-client",
   "dependencies": {
     "oauth": "^0.9.15",
     "object-sizeof": "^1.6.1"

--- a/src/generator/writeTypesInterfaces.ts
+++ b/src/generator/writeTypesInterfaces.ts
@@ -36,7 +36,10 @@ function writeTypesInterfaces(dictionary: IReferenceDirectory[]) {
           .replace(/\{collection-object\}/g, JSON.stringify(collectionTemplate))
           .replace(/\{mention-object\}/g, JSON.stringify(mentionTemplate))
           .replace(/\{geo-object\}/g, JSON.stringify(geoTemplate))
-          .replace(/\{geo-reverse-object\}/g, JSON.stringify(geoReverseTemplate));
+          .replace(
+            /\{geo-reverse-object\}/g,
+            JSON.stringify(geoReverseTemplate)
+          );
 
         try {
           const parsed = JSON.parse(exampleResponse);
@@ -46,7 +49,7 @@ function writeTypesInterfaces(dictionary: IReferenceDirectory[]) {
             if (name === 'RootObject') {
               interfacesContent += `export default ${interfaceContent.replace(
                 'RootObject',
-                fileName,
+                fileName
               )}\n\n`;
             } else {
               interfacesContent += `export ${interfaceContent}\n\n`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import { resolve } from 'path';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import writeParamsInterfaces from './generator/writeParamsInterfaces';
-import createFolderStructure, { copyBase } from './generator/createFolderStructure';
+import createFolderStructure, {
+  copyBase,
+} from './generator/createFolderStructure';
 import writeTypesInterfaces from './generator/writeTypesInterfaces';
 import writeClients from './generator/writeClients';
 import writeReferences from './generator/writeReferences';
@@ -32,7 +34,9 @@ async function start() {
 let dictionary: any;
 
 async function parseDictionary() {
-  dictionary = await $RefParser.dereference(resolve(__dirname, './specs/twitter-api-spec.yml'));
+  dictionary = await $RefParser.dereference(
+    resolve(__dirname, './specs/twitter-api-spec.yml')
+  );
 }
 
 function createParamsInterfaces() {

--- a/src/specs/twitter-api-spec.yml
+++ b/src/specs/twitter-api-spec.yml
@@ -28,3 +28,9 @@
 
 # TWEETS
 - $ref: v2/tweets.yml
+
+# TIMELINES
+- $ref: v2/timelines.yml
+
+# USERS
+- $ref: v2/users.yml

--- a/src/specs/v2/timelines.yml
+++ b/src/specs/v2/timelines.yml
@@ -1,0 +1,112 @@
+title: timelines
+subgroups:
+  - title: Get tweets from a single user
+    endpoints:
+      - title: GET tweets by user id
+        url: https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets
+        resourceUrl: https://api.twitter.com/2/user/:id/tweets
+        description: Returns Tweets composed by a single user, specified by the requested user ID. By default, the most recent ten Tweets are returned per request. Using pagination, the most recent 3,200 Tweets can be retrieved. The Tweets returned by this endpoint count towards the Project-level Tweet cap.
+        parameters:
+          - name: id
+            description: Unique identifier of the Twitter account (user ID) for whom to return results. User ID can be referenced using the user/lookup endpoint.
+            required: true
+            type: string
+          - name: end_time
+            description: YYYY-MM-DDTHH:mm:ssZ (ISO 8601/RFC 3339). The newest or most recent UTC timestamp from which the Tweets will be provided. Only the 3200 most recent Tweets are available. Timestamp is in second granularity and is inclusive (for example, 12:00:01 includes the first second of the minute). Minimum allowable time is 2010-11-06T00:00:01Z. Please note that this parameter does not support a millisecond value.
+            required: false
+            type: date
+          - name: exclude
+            description: Comma-separated list of the types of Tweets to exclude from the response.
+            required: false
+            type: enum
+          - name: expansions
+            description: Expansions enable you to request additional data objects that relate to the originally returned Tweets. Submit a list of desired expansions in a comma-separated list without spaces.
+            required: false
+            type: string
+          - name: max_results
+            description: Specifies the number of Tweets to try and retrieve, up to a maximum of 100 per distinct request. By default, 10 results are returned if this parameter is not supplied.
+            required: false
+            type: integer
+          - name: media.fields
+            description: This fields parameter enables you to select which specific media fields will deliver in each returned Tweet.
+            required: false
+            type: enum
+          - name: pagination_token
+            description: This parameter is used to move forwards or backwards through 'pages' of results, based on the value of the next_token or previous_token in the response.
+            required: false
+            type: string
+          - name: place.fields
+            description: This fields parameter enables you to select which specific place fields will deliver in each returned Tweet.
+            required: false
+            type: enum
+          - name: poll.fields
+            description: Enables you to select which specific poll fields will deliver in each returned Tweet.
+            required: false
+            type: enum
+          - name: since_id
+            description: Returns results with a Tweet ID greater than (that is, more recent than) the specified 'since' Tweet ID.
+            required: false
+            type: date
+          - name: tweet.fields
+            description: Enables you to select which specific Tweet fields will deliver in each returned Tweet object.
+            required: false
+            type: date
+          - name: until_id
+            description: Returns results with a Tweet ID less less than (that is, older than) the specified 'until' Tweet ID.
+            required: false
+            type: string
+          - name: user.fields
+            description: Enables you to select which specific user fields will deliver in each returned Tweet.
+            required: false
+            type: enum
+        exampleResponse: |
+          {
+            "data": [
+              {
+                "id": "1338971066773905408",
+                "text": "💡 Using Twitter data for academic research? Join our next livestream this Friday @ 9am PT on https://t.co/GrtBOXh5Y1!n n@SuhemParack will show how to get started with recent search &amp; filtered stream endpoints on the #TwitterAPI v2, the new Tweet payload, annotations, &amp; more. https://t.co/IraD2Z7wEg"
+              },
+              {
+                "id": "1338923691497959425",
+                "text": "📈 Live now with @jessicagarson and @i_am_daniele! https://t.co/Y1AFzsTTxb"
+              },
+              {
+                "id": "1337498609819021312",
+                "text": "Thanks to everyone who tuned in today to make music with the #TwitterAPI!nnNext week on Twitch - @iamdaniele and @jessicagarson will show you how to integrate the #TwitterAPI and Google Sheets 📈. Tuesday, Dec 15th at 2pm ET. nnhttps://t.co/SQziic6eyp"
+              },
+              {
+                "id": "1337464482654793740",
+                "text": "🎧💻 We're live! Tune in! 🎶 https://t.co/FSYP4rJdHr"
+              },
+              {
+                "id": "1337122535188652033",
+                "text": "👂We want to hear what you think about our plans. As we continue to build our new product tracks, your feedback is essential to shaping the future of the Twitter API. Share your thoughts on this survey: https://t.co/dkIqFGPji7"
+              },
+              {
+                "id": "1337122534173663235",
+                "text": "Is 2020 over yet?nDespite everything that happened this year, thousands of you still made the time to learn, play, and build incredible things on the new #TwitterAPI.nWe want to share some of your stories and give you a preview of what’s to come next year.nhttps://t.co/VpOKT22WgF"
+              },
+              {
+                "id": "1336463248510623745",
+                "text": "🎧 Headphones on: watch @jessicagarson build an interactive app to write music using SuperCollider, Python, FoxDot, and the new Twitter API. Streaming Friday 1:30 ET on our new Twitch channel 🎶💻 https://t.co/SQziic6eyp"
+              },
+              {
+                "id": "1334987486343299072",
+                "text": "console.log('Happy birthday, JavaScript!');"
+              },
+              {
+                "id": "1334920270587584521",
+                "text": "Live now!nJoin the first ever @Twitch stream from TwitterDev https://t.co/x33fiVIi7B"
+              },
+              {
+                "id": "1334564488884862976",
+                "text": "Before we release new #TwitterAPI endpoints, we let developers test drive a prototype of our intended design. @i_am_daniele takes you behind the scenes of an endpoint in the making. https://t.co/NNTDnciwNq"
+              }
+            ],
+            "meta": {
+              "oldest_id": "1334564488884862976",
+              "newest_id": "1338971066773905408",
+              "result_count": 10,
+              "next_token": "7140dibdnow9c7btw3w29grvxfcgvpb9n9coehpk7xz5i"
+            }
+          }

--- a/src/specs/v2/timelines.yml
+++ b/src/specs/v2/timelines.yml
@@ -2,23 +2,15 @@ title: timelines
 subgroups:
   - title: Get tweets from a single user
     endpoints:
-      - title: GET tweets by user id
+      - title: GET users/id/tweets
         url: https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets
-        resourceUrl: https://api.twitter.com/2/user/:id/tweets
+        resourceUrl: https://api.twitter.com/2/users/:id/tweets
         description: Returns Tweets composed by a single user, specified by the requested user ID. By default, the most recent ten Tweets are returned per request. Using pagination, the most recent 3,200 Tweets can be retrieved. The Tweets returned by this endpoint count towards the Project-level Tweet cap.
         parameters:
           - name: id
             description: Unique identifier of the Twitter account (user ID) for whom to return results. User ID can be referenced using the user/lookup endpoint.
             required: true
             type: string
-          - name: end_time
-            description: YYYY-MM-DDTHH:mm:ssZ (ISO 8601/RFC 3339). The newest or most recent UTC timestamp from which the Tweets will be provided. Only the 3200 most recent Tweets are available. Timestamp is in second granularity and is inclusive (for example, 12:00:01 includes the first second of the minute). Minimum allowable time is 2010-11-06T00:00:01Z. Please note that this parameter does not support a millisecond value.
-            required: false
-            type: date
-          - name: exclude
-            description: Comma-separated list of the types of Tweets to exclude from the response.
-            required: false
-            type: enum
           - name: expansions
             description: Expansions enable you to request additional data objects that relate to the originally returned Tweets. Submit a list of desired expansions in a comma-separated list without spaces.
             required: false
@@ -26,39 +18,15 @@ subgroups:
           - name: max_results
             description: Specifies the number of Tweets to try and retrieve, up to a maximum of 100 per distinct request. By default, 10 results are returned if this parameter is not supplied.
             required: false
-            type: integer
-          - name: media.fields
-            description: This fields parameter enables you to select which specific media fields will deliver in each returned Tweet.
-            required: false
-            type: enum
+            type: number
           - name: pagination_token
             description: This parameter is used to move forwards or backwards through 'pages' of results, based on the value of the next_token or previous_token in the response.
             required: false
             type: string
-          - name: place.fields
-            description: This fields parameter enables you to select which specific place fields will deliver in each returned Tweet.
-            required: false
-            type: enum
-          - name: poll.fields
-            description: Enables you to select which specific poll fields will deliver in each returned Tweet.
-            required: false
-            type: enum
-          - name: since_id
-            description: Returns results with a Tweet ID greater than (that is, more recent than) the specified 'since' Tweet ID.
-            required: false
-            type: date
-          - name: tweet.fields
-            description: Enables you to select which specific Tweet fields will deliver in each returned Tweet object.
-            required: false
-            type: date
           - name: until_id
             description: Returns results with a Tweet ID less less than (that is, older than) the specified 'until' Tweet ID.
             required: false
             type: string
-          - name: user.fields
-            description: Enables you to select which specific user fields will deliver in each returned Tweet.
-            required: false
-            type: enum
         exampleResponse: |
           {
             "data": [

--- a/src/specs/v2/users.yml
+++ b/src/specs/v2/users.yml
@@ -2,24 +2,12 @@ title: users
 subgroups:
   - title: Get information about an authorized user
     endpoints:
-      - title: GET /2/users/me
+      - title: GET /users/me
         url: https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me
         resourceUrl: https://api.twitter.com/2/users/me
         description: |
-          Return user informatino about an authorized user. User rate limit for OAuth 2.0 and OAuth 1.0a: 75 requests per 15-minute window per each authenticated user.
+          Return user information about an authorized user. User rate limit for OAuth 2.0 and OAuth 1.0a: 75 requests per 15-minute window per each authenticated user.
         parameters:
-          - name: expansions
-            description: request additional data objects that relate to the originally returned users.
-            required: false
-            type: enum
-          - name: tweet.fields
-            description: Enables you to select which specific Tweet fields will deliver in each returned pinned Tweet.
-            required: false
-            type: enum
-          - name: user.fields
-            description: Enables you to select which specific user fields will deliver with each returned users objects.
-            required: false
-            type: enum
         exampleResponse: |
           {
             "data": {

--- a/src/specs/v2/users.yml
+++ b/src/specs/v2/users.yml
@@ -1,0 +1,30 @@
+title: users
+subgroups:
+  - title: Get information about an authorized user
+    endpoints:
+      - title: GET /2/users/me
+        url: https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me
+        resourceUrl: https://api.twitter.com/2/users/me
+        description: |
+          Return user informatino about an authorized user. User rate limit for OAuth 2.0 and OAuth 1.0a: 75 requests per 15-minute window per each authenticated user.
+        parameters:
+          - name: expansions
+            description: request additional data objects that relate to the originally returned users.
+            required: false
+            type: enum
+          - name: tweet.fields
+            description: Enables you to select which specific Tweet fields will deliver in each returned pinned Tweet.
+            required: false
+            type: enum
+          - name: user.fields
+            description: Enables you to select which specific user fields will deliver with each returned users objects.
+            required: false
+            type: enum
+        exampleResponse: |
+          {
+            "data": {
+              "id": "2244994945",
+              "name": "TwitterDev",
+              "username": "Twitter Dev"
+            }
+          }


### PR DESCRIPTION
**What does this pull request introduce? Please describe**  
This pull request introduces two additional v2 endpoints:

1. User Tweet timeline endpoint which returns the most recent Tweets composed by a specified user ID.
2. A user lookup that returns information about an authorized user.

It also includes a few small tweaks to the contrib guide to make the instructions more accurate.

**How did you verify that your changes work as expected? Please describe**  
I followed the instructions for manual testing in the contrib guide. Namely, I created a new node project locally, installed my version of the client, and then consumed it.

**Example**  
Please describe how we can try out your changes

1. Create a new node project
2. Install this version of the client
3. Supply the client your Twitter developer credentials
4. Use the `users.usersMe` endpoint to retrieve your authenticated user's id string.
5. Pass that id string to the `timelines.usersIdTweets` endpoint.
6. Log the results to the console.

**Screenshots**  
In this screenshot, you can see the two new endpoints as well as the data they returned printed in the console:

![Screen Shot 2022-01-15 at 4 16 06 PM](https://user-images.githubusercontent.com/41495147/149639561-01a6eb1f-95c7-4815-9f93-465d921b0ee6.png)

Screenshot of existing unit tests passing:

![Screen Shot 2022-01-15 at 4 14 31 PM](https://user-images.githubusercontent.com/41495147/149639632-aaf89aaf-733e-483f-b127-3a8c82873b06.png)


**Version**  
1.5.2

**PR Checklist**
Please verify that you:

- [x] Ran all unit tests, and they are passing
- [x] Wrote new unit tests if appropriate
- [x] Installed the client locally and tested it manually
- [x] Updated the version in `package.json`
